### PR TITLE
Default the constructor object

### DIFF
--- a/packages/workgrid-micro-app/package.json
+++ b/packages/workgrid-micro-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workgrid/micro-app",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "main": "dist/micro-app.js",
   "types": "dist/micro-app.d.ts",
   "browser": "dist/micro-app.umd.js",

--- a/packages/workgrid-micro-app/src/micro-app.test.ts
+++ b/packages/workgrid-micro-app/src/micro-app.test.ts
@@ -15,7 +15,7 @@ describe('@workgrid/micro-app', () => {
 
   describe('constructor', () => {
     test('will create a new instance of courier', () => {
-      const microApp = new MicroApp({ audience: 'https://www.workgrid.com' })
+      const microApp = new MicroApp()
       expect(microApp.courier).toBeInstanceOf(Courier)
     })
   })

--- a/packages/workgrid-micro-app/src/micro-app.ts
+++ b/packages/workgrid-micro-app/src/micro-app.ts
@@ -61,7 +61,7 @@ class MicroApp {
   private ro: any
   private token?: string
 
-  public constructor({ audience, onError, id }: MicroAppOptions) {
+  public constructor({ audience, onError, id }: MicroAppOptions = {}) {
     if (audience) console && console.warn('Providing an audience is deprecated')
 
     this.audience = audience


### PR DESCRIPTION
The readme states that you can do a simple constructor:
```
new MicroApp()
```
This change allows for that.