### PR TITLE
Bind `handleMessage` so it does not lose `this` context.

### DIFF
--- a/packages/workgrid-courier/package.json
+++ b/packages/workgrid-courier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workgrid/courier",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "main": "dist/courier.js",
   "types": "dist/courier.d.ts",
   "browser": "dist/courier.umd.js",

--- a/packages/workgrid-courier/src/courier.ts
+++ b/packages/workgrid-courier/src/courier.ts
@@ -72,6 +72,7 @@ export default class Courier {
     this.internal = emitter()
     this.emitter = emitter()
 
+    this.handleMessage = this.handleMessage.bind(this)
     this.setup()
   }
 

--- a/packages/workgrid-micro-app/package.json
+++ b/packages/workgrid-micro-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workgrid/micro-app",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "main": "dist/micro-app.js",
   "types": "dist/micro-app.d.ts",
   "browser": "dist/micro-app.umd.js",
@@ -22,7 +22,7 @@
     "url": "https://github.com/Workgrid/workgrid-javascript"
   },
   "dependencies": {
-    "@workgrid/courier": "^0.7.0",
+    "@workgrid/courier": "^0.7.1",
     "jwt-decode": "^2.2.0",
     "lodash": "^4.17.11",
     "ms": "^2.1.1",


### PR DESCRIPTION
With a recent change to the Microapp SDK `handleMessage` became unbound and lost `this` context on occasion. The root of the issue was a commit that removed class properties which implicitly bound to `this`. This change explicitly binds `this` for `handleMessage` so it can run under the correct context.