### PR TITLE
Pin 'debug' in @workgrid/courier as we are relying on some internals

### DIFF
--- a/packages/workgrid-courier/package.json
+++ b/packages/workgrid-courier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workgrid/courier",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "main": "dist/courier.js",
   "types": "dist/courier.d.ts",
   "browser": "dist/courier.umd.js",
@@ -22,7 +22,7 @@
     "url": "https://github.com/Workgrid/workgrid-javascript"
   },
   "dependencies": {
-    "debug": "^4.1.1",
+    "debug": "4.1.1",
     "lodash": "^4.17.11",
     "ms": "^2.1.1",
     "nice-try": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2572,6 +2572,13 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+debug@4.1.1, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
+  dependencies:
+    ms "^2.1.1"
+
 debug@=3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
@@ -2585,13 +2592,6 @@ debug@^2.2.0, debug@^2.3.3:
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
-
-debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
-  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
-  dependencies:
-    ms "^2.1.1"
 
 decamelize@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
I don't remember exactly why we are using `import debug from 'debug/dist/debug'` but the dist folder goes away in >= 4.2, so pinning to 4.1.1 for now
https://github.com/Workgrid/workgrid-javascript/blob/master/packages/workgrid-courier/src/courier.ts#L19