### PR TITLE
Bump @workgrid/courier in @workgrid/micro-app for renovate

### DIFF
--- a/packages/workgrid-micro-app/package.json
+++ b/packages/workgrid-micro-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workgrid/micro-app",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "main": "dist/micro-app.js",
   "types": "dist/micro-app.d.ts",
   "browser": "dist/micro-app.umd.js",
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@juggle/resize-observer": "^3.3.0",
-    "@workgrid/courier": "^0.7.1",
+    "@workgrid/courier": "^0.7.2",
     "jwt-decode": "^2.2.0",
     "lodash": "^4.17.11",
     "ms": "^2.1.1",


### PR DESCRIPTION
Renovate won't pick up changes for nested dependencies, just direct dependencies - so a small bump to trigger that.