### PR TITLE
Make userAgent a required context parameter for better support in node

### DIFF
--- a/packages/workgrid-client-react/src/client-react.test.ts
+++ b/packages/workgrid-client-react/src/client-react.test.ts
@@ -56,7 +56,13 @@ describe('@workgrid/client-react', () => {
   let renderHook: typeof _renderHook
 
   beforeEach(() => {
-    client = new WorkgridClient({ context: { token: 'token', companyCode: 'company-code' } })
+    client = new WorkgridClient({
+      context: {
+        userAgent: navigator.userAgent,
+        token: 'token',
+        companyCode: 'company-code',
+      },
+    })
 
     renderHook = <TProps, TResult>(callback: (props: TProps) => TResult, options?: RenderHookOptions<TProps>) => {
       return _renderHook(callback, { wrapper: (props) => h(WorkgridProvider, { client, ...props }), ...options })

--- a/packages/workgrid-client/src/client.test.ts
+++ b/packages/workgrid-client/src/client.test.ts
@@ -66,7 +66,13 @@ describe('@workgrid/client', () => {
   let client: WorkgridClient
 
   beforeEach(() => {
-    client = new WorkgridClient({ context: { token: 'token', companyCode: 'company-code' } })
+    client = new WorkgridClient({
+      context: {
+        userAgent: navigator.userAgent,
+        token: 'token',
+        companyCode: 'company-code',
+      },
+    })
   })
 
   test('query', async () => {

--- a/packages/workgrid-client/src/client.ts
+++ b/packages/workgrid-client/src/client.ts
@@ -42,14 +42,14 @@ export type Context = {
   token: string
   apiHost: string
   wssHost: string
-  userAgent: string
+  userAgent: string // Use navigator.userAgent in browser, use a relevant string in node
   clientAgent: string
 }
 
 /** @beta */
 export type PartialContext =
-  | (Pick<Context, 'token'> & { apiHost: string; wssHost?: string })
-  | (Pick<Context, 'token'> & { companyCode: string })
+  | (Pick<Context, 'token' | 'userAgent'> & { apiHost: string; wssHost?: string })
+  | (Pick<Context, 'token' | 'userAgent'> & { companyCode: string })
 
 /** @beta */
 export type ClientOptions = {
@@ -232,12 +232,11 @@ export default Client
  * @returns A normalized context object
  */
 async function normalizeContext(context: ClientOptions['context']): Promise<Context> {
-  const { token, ...partial } = typeof context === 'function' ? await context() : context
+  const { token, userAgent, ...partial } = typeof context === 'function' ? await context() : context
 
   const apiHost = 'apiHost' in partial ? partial.apiHost : `https://${partial.companyCode}.workgrid.com`
   const wssHost = 'wssHost' in partial && partial.wssHost ? partial.wssHost : apiHost.replace('https://', 'wss://')
 
-  const userAgent = navigator.userAgent
   const clientAgent = `${pkg.name}/${pkg.version}`
 
   return { token, apiHost, wssHost, userAgent, clientAgent }


### PR DESCRIPTION
Making `userAgent` a required parameter so `navigator.userAgent` can be provided in a browser context, and a relevant string can be provided in a node (server) context.