### PR TITLE
Add me query

### DIFF
--- a/packages/workgrid-client/src/client.test.ts
+++ b/packages/workgrid-client/src/client.test.ts
@@ -49,6 +49,11 @@ const server = setupServer(
   }),
   rest.put(`https://company-code.workgrid.com/v1/usernotifications/:id/view-detail`, (req, res, ctx) => {
     return res(ctx.json({ data: { id: req.params.id, title: `${req.method} ${req.url.pathname}` } }))
+  }),
+  rest.post(`https://company-code.workgrid.com/v1/graphql`, (req, res, ctx) => {
+    return res(
+      ctx.json({ data: { currentUser: { id: '123124', name: { familyName: 'familyName', givenName: 'givenName' } } } })
+    )
   })
 )
 
@@ -121,6 +126,22 @@ describe('@workgrid/client', () => {
             "name": "Space 1",
           },
         ]
+      `)
+    })
+
+    test('me', async () => {
+      const result = await client.query(['me'])
+
+      expect(result).toMatchInlineSnapshot(`
+        Object {
+          "currentUser": Object {
+            "id": "123124",
+            "name": Object {
+              "familyName": "familyName",
+              "givenName": "givenName",
+            },
+          },
+        }
       `)
     })
 

--- a/packages/workgrid-client/src/client.test.ts
+++ b/packages/workgrid-client/src/client.test.ts
@@ -20,7 +20,7 @@ import { rest } from 'msw'
 import WorkgridClient from './client'
 
 const server = setupServer(
-  rest.post(`https://company-code.workgrid.com/v1/userspaces`, (req, res, ctx) => {
+  rest.get(`https://company-code.workgrid.com/v1/userspaces`, (req, res, ctx) => {
     return res(ctx.json({ data: [{ id: 'space1', name: 'Space 1', default: true }] }))
   }),
   rest.post(`https://company-code.workgrid.com/v1/flags`, (req, res, ctx) => {
@@ -51,9 +51,7 @@ const server = setupServer(
     return res(ctx.json({ data: { id: req.params.id, title: `${req.method} ${req.url.pathname}` } }))
   }),
   rest.post(`https://company-code.workgrid.com/v1/graphql`, (req, res, ctx) => {
-    return res(
-      ctx.json({ data: { currentUser: { id: '123124', name: { familyName: 'familyName', givenName: 'givenName' } } } })
-    )
+    return res(ctx.json({ data: { id: '123124', name: { familyName: 'familyName', givenName: 'givenName' } } }))
   })
 )
 
@@ -134,12 +132,10 @@ describe('@workgrid/client', () => {
 
       expect(result).toMatchInlineSnapshot(`
         Object {
-          "currentUser": Object {
-            "id": "123124",
-            "name": Object {
-              "familyName": "familyName",
-              "givenName": "givenName",
-            },
+          "id": "123124",
+          "name": Object {
+            "familyName": "familyName",
+            "givenName": "givenName",
           },
         }
       `)

--- a/packages/workgrid-client/src/client.test.ts
+++ b/packages/workgrid-client/src/client.test.ts
@@ -51,7 +51,9 @@ const server = setupServer(
     return res(ctx.json({ data: { id: req.params.id, title: `${req.method} ${req.url.pathname}` } }))
   }),
   rest.post(`https://company-code.workgrid.com/v1/graphql`, (req, res, ctx) => {
-    return res(ctx.json({ data: { id: '123124', name: { familyName: 'familyName', givenName: 'givenName' } } }))
+    return res(
+      ctx.json({ data: { currentUser: { id: '123124', name: { familyName: 'familyName', givenName: 'givenName' } } } })
+    )
   })
 )
 

--- a/packages/workgrid-client/src/client.ts
+++ b/packages/workgrid-client/src/client.ts
@@ -37,6 +37,8 @@ export { HttpClient, WsClient }
 // Use require to avoid ts6059
 const pkg = require('../package.json')
 
+const gql = String.raw // better editor integrations
+
 /** @beta */
 export type Context = {
   token: string
@@ -357,10 +359,19 @@ export interface Queries {
 setTypedQueryDefaults('me', (client) => ({
   queryFn: async () => {
     const response = await client.httpClient.post('/v1/graphql', {
-      query:
-        'query currentUser($authContext: AuthContext!) { currentUser(authContext: $authContext) { id, name { familyName, givenName } } }',
+      query: gql`
+        query currentUser($authContext: AuthContext!) {
+          currentUser(authContext: $authContext) {
+            id
+            name {
+              familyName
+              givenName
+            }
+          }
+        }
+      `,
     })
-    return response.data
+    return response.data.currentUser
   },
 }))
 

--- a/packages/workgrid-client/src/client.ts
+++ b/packages/workgrid-client/src/client.ts
@@ -325,9 +325,6 @@ export type Notification = { [key: string]: unknown }
 /** @beta */
 export type App = { [key: string]: unknown }
 
-/** @beta */
-export type CurrentUser = { id: string; name: { familyName: string; givenName: string } }
-
 // getSpaces
 // ================================================================================================================================
 
@@ -341,7 +338,7 @@ export interface Queries {
 
 setTypedQueryDefaults('getSpaces', (client) => ({
   queryFn: async () => {
-    const response = await client.httpClient.post(`/v1/userspaces`)
+    const response = await client.httpClient.get(`/v1/userspaces`)
     return response.data
   },
 }))
@@ -350,7 +347,7 @@ setTypedQueryDefaults('getSpaces', (client) => ({
 // ================================================================================================================================
 
 /** @beta */
-export type Me = { currentUser: CurrentUser }
+export type Me = { id: string; name: { familyName: string; givenName: string } }
 
 /** @beta */
 export interface Queries {

--- a/packages/workgrid-client/src/client.ts
+++ b/packages/workgrid-client/src/client.ts
@@ -325,6 +325,9 @@ export type Notification = { [key: string]: unknown }
 /** @beta */
 export type App = { [key: string]: unknown }
 
+/** @beta */
+export type CurrentUser = { id: string; name: { familyName: string; givenName: string } }
+
 // getSpaces
 // ================================================================================================================================
 
@@ -339,6 +342,27 @@ export interface Queries {
 setTypedQueryDefaults('getSpaces', (client) => ({
   queryFn: async () => {
     const response = await client.httpClient.post(`/v1/userspaces`)
+    return response.data
+  },
+}))
+
+// me
+// ================================================================================================================================
+
+/** @beta */
+export type Me = { currentUser: CurrentUser }
+
+/** @beta */
+export interface Queries {
+  me: Query<['me'], Me>
+}
+
+setTypedQueryDefaults('me', (client) => ({
+  queryFn: async () => {
+    const response = await client.httpClient.post('/v1/graphql', {
+      query:
+        'query currentUser($authContext: AuthContext!) { currentUser(authContext: $authContext) { id, name { familyName, givenName } } }',
+    })
     return response.data
   },
 }))


### PR DESCRIPTION
Provide the ability to obtain the current user information via a 'me' query. The information returned includes the id and some additional information pertaining to the user's name.

Changed the getSpaces query to invoke get rather than post - to match endpoint expectations