### PR TITLE
Change debug import to fix api docs typing issue

### DIFF
--- a/packages/workgrid-courier/package.json
+++ b/packages/workgrid-courier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workgrid/courier",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "main": "dist/courier.js",
   "types": "dist/courier.d.ts",
   "unpkg": "dist/courier.umd.js",

--- a/packages/workgrid-courier/src/courier.ts
+++ b/packages/workgrid-courier/src/courier.ts
@@ -16,7 +16,7 @@
 
 import emitter, { Handler } from './emitter'
 import niceTry from 'nice-try'
-import debug from 'debug'
+import { debug } from 'debug'
 import { v4 as uuid } from 'uuid'
 import ms from 'ms'
 

--- a/packages/workgrid-micro-app/package.json
+++ b/packages/workgrid-micro-app/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@juggle/resize-observer": "^3.3.0",
-    "@workgrid/courier": "^0.7.4",
+    "@workgrid/courier": "^0.7.5",
     "jwt-decode": "^3.1.2",
     "lodash": "^4.17.11",
     "ms": "^2.1.1",


### PR DESCRIPTION
So, while the build "passed" there was an error publishing `@workgrid/micro-app` after #57 was merged.
Turns out there was a problem with the types for `debug` and it caused the api docs for micro-app to fail and block publishing. Switching to a named import fixes all the things. Bumping courier to include this change, not bumping micro-app as the last publish didn't work anyway.