### PR TITLE
ETSWORK-11824 1 line fix, an hour+ to write imperfect tests

### DIFF
--- a/packages/workgrid-courier/package.json
+++ b/packages/workgrid-courier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workgrid/courier",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "main": "dist/courier.js",
   "types": "dist/courier.d.ts",
   "unpkg": "dist/courier.umd.js",

--- a/packages/workgrid-courier/src/courier.ts
+++ b/packages/workgrid-courier/src/courier.ts
@@ -225,6 +225,10 @@ export default class Courier {
         channel.port1.onmessage = (event): void => {
           this.debug('onmessage', { event, target, channel })
 
+          // sendMessage defaults target to the first registered source
+          // we need to apply the same logic here so source is consistent
+          target = target || this.sources[0]
+
           // TODO: Passing a new instance of MessageEvent doesn't work in react-native :(
           // this.handleMessage(new MessageEvent('message', { data: event.data, source: target }))
           this.handleMessage({ data: event.data, source: target } as MessageEvent)

--- a/packages/workgrid-micro-app/package.json
+++ b/packages/workgrid-micro-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workgrid/micro-app",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "main": "dist/micro-app.js",
   "types": "dist/micro-app.d.ts",
   "unpkg": "dist/micro-app.umd.js",
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@juggle/resize-observer": "^3.3.0",
-    "@workgrid/courier": "^0.7.6",
+    "@workgrid/courier": "^0.7.7",
     "jwt-decode": "^3.1.2",
     "lodash": "^4.17.11",
     "ms": "^2.1.1",


### PR DESCRIPTION
In https://github.com/Workgrid/workgrid-javascript/pull/390 events without a source were ignored.
This revealed a bug where messages sent via MessageChannel without an explicit target would have an undefined event source. The bit of logic where the target defaults to the first registered source happened after the MessageChannel listener is registered. Duplicating the logic for consistency.

Also, discovered our tests did not validate the behavior when a MessageChannel is used (not defined in JSDOM). Added a super naive mock & wrapped the test suite to run with and without the mock, confirming the code does fail without the added change.

Note: When a target is not specified, we are defaulting to the first registered source which will always be the parent window. This should work fine for apps, but may not be the most correct for our clients.