### PR TITLE
Axios post takes 3 params.

### DIFF
--- a/packages/workgrid-client-react/package.json
+++ b/packages/workgrid-client-react/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@testing-library/react-hooks": "^5.1.0",
-    "@workgrid/client": "^0.0.6",
+    "@workgrid/client": "^0.0.7",
     "react-query": "^3.12.2"
   },
   "devDependencies": {

--- a/packages/workgrid-client/package.json
+++ b/packages/workgrid-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workgrid/client",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "main": "dist/client.js",
   "types": "dist/client.d.ts",
   "files": [

--- a/packages/workgrid-client/src/client.ts
+++ b/packages/workgrid-client/src/client.ts
@@ -409,7 +409,7 @@ export interface Queries {
 setTypedQueryDefaults('getFlags', (client) => ({
   queryFn: async (context) => {
     const { spaceId } = context.queryKey[1]
-    const response = await client.httpClient.post(`/v1/flags`, {
+    const response = await client.httpClient.post(`/v1/flags`, null, {
       headers: { 'x-workgrid-space': spaceId },
     })
     return mapValues(response.data.data, 'value') /* unwrap jsend */


### PR DESCRIPTION
The flags api leverages the Axios Post operation which takes 3 params. In the current implementation the header information was mapped to the 2nd param (the data param). As such updated request payload to default data param to null.

Please note the Data param is not used within the underlying service.